### PR TITLE
Avoid copy if p=1 in ndPAC

### DIFF
--- a/tensorpac/methods/meth_pac.py
+++ b/tensorpac/methods/meth_pac.py
@@ -201,7 +201,9 @@ def ndpac(pha, amp, p=.05):
         Respectively the arrays of phases of shape (n_pha, ..., n_times) and
         the array of amplitudes of shape (n_amp, ..., n_times).
     p : float | .05
-        P-value to use for thresholding
+        P-value to use for thresholding. Sub-threshold PAC values
+        will be set to 0. To disable this behavior (no masking), use ``p=1`` or
+        ``p=None``.
 
     Returns
     -------
@@ -220,6 +222,11 @@ def ndpac(pha, amp, p=.05):
     amp = np.divide(amp, np.std(amp, axis=-1, keepdims=True))
     # Compute pac :
     pac = np.abs(np.einsum('i...j, k...j->ik...', amp, np.exp(1j * pha)))
+
+    if p == 1. or p is None:
+        # No thresholding
+        return pac / npts
+
     s = pac**2
     pac /= npts
     # Set to zero non-significant values:

--- a/tensorpac/methods/meth_pac.py
+++ b/tensorpac/methods/meth_pac.py
@@ -218,8 +218,9 @@ def ndpac(pha, amp, p=.05):
     """
     npts = amp.shape[-1]
     # Normalize amplitude :
+    # Use the sample standard deviation, as in original Matlab code from author
     amp = np.subtract(amp, np.mean(amp, axis=-1, keepdims=True))
-    amp = np.divide(amp, np.std(amp, axis=-1, keepdims=True))
+    amp = np.divide(amp, np.std(amp, ddof=1, axis=-1, keepdims=True))
     # Compute pac :
     pac = np.abs(np.einsum('i...j, k...j->ik...', amp, np.exp(1j * pha)))
 

--- a/tensorpac/methods/tests/test_pac_methods.py
+++ b/tensorpac/methods/tests/test_pac_methods.py
@@ -64,6 +64,10 @@ class TestMethods(object):
                 _pha = np.stack([np.sin(pha), np.cos(pha)], axis=-2)
                 _amp = amp[..., np.newaxis, :]
                 pac = meth(_pha, _amp)
+            elif n + 1 == 4:  # Try with different values of p for coverage
+                pac = meth(pha, amp, p=0.5)
+                pac = meth(pha, amp, p=1)
+                pac = meth(pha, amp, p=None)
             else:
                 pac = meth(pha, amp)
             assert pac.shape == (n_amp_freqs, n_pha_freqs, n_epochs)


### PR DESCRIPTION
Just two minor additions in ndpac (last PR I promise :-))

1. Allow ``p=None`` to explicitly disable masking (which can also be done using ``p=1``)

2. Avoid creating the ``s`` array if masking is disabled