### PR TITLE
Remove top level import of matplotlib in utils.py

### DIFF
--- a/tensorpac/utils.py
+++ b/tensorpac/utils.py
@@ -8,9 +8,6 @@ from tensorpac.methods.meth_pac import _kl_hr
 from tensorpac.pac import _PacObj, _PacVisual
 from tensorpac.io import set_log_level
 
-from matplotlib.gridspec import GridSpec
-import matplotlib.pyplot as plt
-
 logger = logging.getLogger('tensorpac')
 
 
@@ -239,6 +236,7 @@ class PSD(object):
         ax : Matplotlib axis
             The matplotlib axis that contains the figure
         """
+        import matplotlib.pyplot as plt
         # manage input variables
         kw['fz_labels'] = kw.get('fz_labels', fz_labels)
         kw['fz_title'] = kw.get('fz_title', fz_title)
@@ -688,6 +686,8 @@ class PeakLockedTF(_PacObj, _PacVisual):
             Additional arguments are sent to the
             :class:`tensorpac.utils.PeakLockedTF.pacplot` method
         """
+        import matplotlib.pyplot as plt
+        from matplotlib.gridspec import GridSpec
         # manage additional arguments
         kwargs['colorbar'] = False
         kwargs['ylabel'] = 'Frequency for amplitude (hz)'


### PR DESCRIPTION
import statements have been added to the PSD and PeakLockedTF classes
as these were the only classes using matplotlib that did not already
include all required import statements

These changes allow importing tensorpac without having matplotlib installed. An import error will only occur when you attempt to use one of the plotting functions in utils.py instead of immediately on module import.