### PR TITLE
Changed basex to base

### DIFF
--- a/tensorpac/utils.py
+++ b/tensorpac/utils.py
@@ -1,17 +1,18 @@
 """Utility functions."""
+
 import logging
 
 import numpy as np
 from scipy.signal import periodogram
 
+from tensorpac.io import set_log_level
 from tensorpac.methods.meth_pac import _kl_hr
 from tensorpac.pac import _PacObj, _PacVisual
-from tensorpac.io import set_log_level
 
-logger = logging.getLogger('tensorpac')
+logger = logging.getLogger("tensorpac")
 
 
-def pac_vec(f_pha='mres', f_amp='mres'):
+def pac_vec(f_pha="mres", f_amp="mres"):
     """Generate cross-frequency coupling vectors.
 
     Parameters
@@ -42,14 +43,14 @@ def pac_vec(f_pha='mres', f_amp='mres'):
         f_pha_nb = nb_fcy[f_pha]
         # f_pha = [f - f / 4, f + f / 4]
         f_pha_mid = np.linspace(f_pha_start, f_pha_end, f_pha_nb)
-        f_pha = np.c_[f_pha_mid - f_pha_mid / 4., f_pha_mid + f_pha_mid / 4.]
+        f_pha = np.c_[f_pha_mid - f_pha_mid / 4.0, f_pha_mid + f_pha_mid / 4.0]
     if isinstance(f_amp, str):
         # get where amplitude frequencies start / finish / number
         f_amp_start, f_amp_end = 60, 160
         f_amp_nb = nb_fcy[f_amp]
         # f_amp = [f - f / 8, f + f / 8]
         f_amp_mid = np.linspace(f_amp_start, f_amp_end, f_amp_nb)
-        f_amp = np.c_[f_amp_mid - f_amp_mid / 8., f_amp_mid + f_amp_mid / 8.]
+        f_amp = np.c_[f_amp_mid - f_amp_mid / 8.0, f_amp_mid + f_amp_mid / 8.0]
 
     return _check_freq(f_pha), _check_freq(f_amp)
 
@@ -61,7 +62,7 @@ def _check_freq(f):
     if len(f.reshape(-1)) == 1:
         raise ValueError("The length of f should at least be 2.")
     elif 2 in f.shape:  # f of shape (N, 2) or (2, N)
-        if f.shape[1] is not 2:
+        if f.shape[1] != 2:
             f = f.T
     elif np.squeeze(f).shape == (4,):  # (f_start, f_end, f_width, f_step)
         f = _pair_vectors(*tuple(np.squeeze(f)))
@@ -79,7 +80,7 @@ def _pair_vectors(f_start, f_end, f_width, f_step):
     return np.c_[fdown, fup]
 
 
-def pac_trivec(f_start=60., f_end=160., f_width=10.):
+def pac_trivec(f_start=60.0, f_end=160.0, f_width=10.0):
     """Generate triangular vector.
 
     By contrast with the pac_vec function, this function generate frequency
@@ -107,7 +108,7 @@ def pac_trivec(f_start=60., f_end=160., f_width=10.):
         # Lentgh of the vector to build :
         le = len(starting) - (num + 1)
         # Create the frequency vector for this starting frequency :
-        fst = np.c_[np.full(le, k), starting[num + 1::]]
+        fst = np.c_[np.full(le, k), starting[num + 1 : :]]
         nfst = fst.shape[0]
         # Create the triangular index for this vector of frequencies :
         idx = np.c_[np.flipud(np.arange(nfst)), np.full(nfst, num)]
@@ -129,19 +130,36 @@ class PSD(object):
 
     def __init__(self, x, sf):
         """Init."""
-        assert isinstance(x, np.ndarray) and (x.ndim == 2), (
-            "x should be a 2d array of shape (n_epochs, n_times)")
+        assert isinstance(x, np.ndarray) and (
+            x.ndim == 2
+        ), "x should be a 2d array of shape (n_epochs, n_times)"
         self._n_trials, self._n_times = x.shape
-        logger.info(f"Compute PSD over {self._n_trials} trials and "
-                    f"{self._n_times} time points")
-        self._freqs, self._psd = periodogram(x, fs=sf, window=None,
-                                             nfft=self._n_times,
-                                             detrend='constant',
-                                             return_onesided=True,
-                                             scaling='density', axis=1)
+        logger.info(
+            f"Compute PSD over {self._n_trials} trials and "
+            f"{self._n_times} time points"
+        )
+        self._freqs, self._psd = periodogram(
+            x,
+            fs=sf,
+            window=None,
+            nfft=self._n_times,
+            detrend="constant",
+            return_onesided=True,
+            scaling="density",
+            axis=1,
+        )
 
-    def plot(self, f_min=None, f_max=None, confidence=95, interp=None,
-             log=False, grid=True, fz_title=18, fz_labels=15):
+    def plot(
+        self,
+        f_min=None,
+        f_max=None,
+        confidence=95,
+        interp=None,
+        log=False,
+        grid=True,
+        fz_title=18,
+        fz_labels=15,
+    ):
         """Plot the PSD.
 
         Parameters
@@ -169,32 +187,38 @@ class PSD(object):
             The matplotlib axis that contains the figure
         """
         import matplotlib.pyplot as plt
+
         f_types = (int, float)
         # interpolation
         xvec, yvec = self._freqs, self._psd
         if isinstance(interp, int) and (interp > 1):
             # from scipy.interpolate import make_interp_spline, BSpline
             from scipy.interpolate import interp1d
+
             xnew = np.linspace(xvec[0], xvec[-1], len(xvec) * interp)
-            f = interp1d(xvec, yvec, kind='quadratic', axis=1)
+            f = interp1d(xvec, yvec, kind="quadratic", axis=1)
             yvec = f(xnew)
             xvec = xnew
         # (f_min, f_max)
         f_min = xvec[0] if not isinstance(f_min, f_types) else f_min
         f_max = xvec[-1] if not isinstance(f_max, f_types) else f_max
         # plot main psd
-        plt.plot(xvec, yvec.mean(0), color='black',
-                 label='mean PSD over trials')
+        plt.plot(xvec, yvec.mean(0), color="black", label="mean PSD over trials")
         # plot confidence interval
         if isinstance(confidence, (int, float)) and (0 < confidence < 100):
             logger.info(f"    Add {confidence}th confidence interval")
-            interval = (100. - confidence) / 2
-            kw = dict(axis=0, interpolation='nearest')
+            interval = (100.0 - confidence) / 2
+            kw = dict(axis=0, interpolation="nearest")
             psd_min = np.percentile(yvec, interval, **kw)
-            psd_max = np.percentile(yvec, 100. - interval, **kw)
-            plt.fill_between(xvec, psd_max, psd_min, color='lightgray',
-                             alpha=0.5,
-                             label=f"{confidence}th confidence interval")
+            psd_max = np.percentile(yvec, 100.0 - interval, **kw)
+            plt.fill_between(
+                xvec,
+                psd_max,
+                psd_min,
+                color="lightgray",
+                alpha=0.5,
+                label=f"{confidence}th confidence interval",
+            )
             plt.legend(fontsize=fz_labels)
         plt.xlabel("Frequencies (Hz)", fontsize=fz_labels)
         plt.ylabel("Power (V**2/Hz)", fontsize=fz_labels)
@@ -202,18 +226,34 @@ class PSD(object):
         plt.xlim(f_min, f_max)
         if log:
             from matplotlib.ticker import ScalarFormatter
-            plt.xscale('log', basex=10)
+
+            plt.xscale("log", base=10)
             plt.gca().xaxis.set_major_formatter(ScalarFormatter())
         if grid:
-            plt.grid(color='grey', which='major', linestyle='-',
-                     linewidth=1., alpha=0.5)
-            plt.grid(color='lightgrey', which='minor', linestyle='--',
-                     linewidth=0.5, alpha=0.5)
+            plt.grid(
+                color="grey", which="major", linestyle="-", linewidth=1.0, alpha=0.5
+            )
+            plt.grid(
+                color="lightgrey",
+                which="minor",
+                linestyle="--",
+                linewidth=0.5,
+                alpha=0.5,
+            )
 
         return plt.gca()
 
-    def plot_st_psd(self, f_min=None, f_max=None, log=False, grid=True,
-                    fz_title=18, fz_labels=15, fz_cblabel=15, **kw):
+    def plot_st_psd(
+        self,
+        f_min=None,
+        f_max=None,
+        log=False,
+        grid=True,
+        fz_title=18,
+        fz_labels=15,
+        fz_cblabel=15,
+        **kw,
+    ):
         """Single-trial PSD plot.
 
         Parameters
@@ -237,14 +277,15 @@ class PSD(object):
             The matplotlib axis that contains the figure
         """
         import matplotlib.pyplot as plt
+
         # manage input variables
-        kw['fz_labels'] = kw.get('fz_labels', fz_labels)
-        kw['fz_title'] = kw.get('fz_title', fz_title)
-        kw['fz_cblabel'] = kw.get('fz_cblabel', fz_title)
-        kw['xlabel'] = kw.get('xlabel', "Frequencies (Hz)")
-        kw['ylabel'] = kw.get('ylabel', "Trials")
-        kw['title'] = kw.get('title', "Single-trial PSD")
-        kw['cblabel'] = kw.get('cblabel', "Power (V**2/Hz)")
+        kw["fz_labels"] = kw.get("fz_labels", fz_labels)
+        kw["fz_title"] = kw.get("fz_title", fz_title)
+        kw["fz_cblabel"] = kw.get("fz_cblabel", fz_title)
+        kw["xlabel"] = kw.get("xlabel", "Frequencies (Hz)")
+        kw["ylabel"] = kw.get("ylabel", "Trials")
+        kw["title"] = kw.get("title", "Single-trial PSD")
+        kw["cblabel"] = kw.get("cblabel", "Power (V**2/Hz)")
         # (f_min, f_max)
         xvec, psd = self._freqs, self._psd
         f_types = (int, float)
@@ -262,19 +303,27 @@ class PSD(object):
         _viz.pacplot(psd, xvec, trials, **kw)
         if log:
             from matplotlib.ticker import ScalarFormatter
-            plt.xscale('log', basex=10)
+
+            plt.xscale("log", base=10)
             plt.gca().xaxis.set_major_formatter(ScalarFormatter())
         if grid:
-            plt.grid(color='grey', which='major', linestyle='-',
-                     linewidth=1., alpha=0.5)
-            plt.grid(color='lightgrey', which='minor', linestyle='--',
-                     linewidth=0.5, alpha=0.5)
+            plt.grid(
+                color="grey", which="major", linestyle="-", linewidth=1.0, alpha=0.5
+            )
+            plt.grid(
+                color="lightgrey",
+                which="minor",
+                linestyle="--",
+                linewidth=0.5,
+                alpha=0.5,
+            )
 
         return plt.gca()
 
     def show(self):
         """Display the PSD figure."""
         import matplotlib.pyplot as plt
+
         plt.show()
 
     @property
@@ -319,34 +368,48 @@ class BinAmplitude(_PacObj):
         Number of samples to discard to avoid edge effects due to filtering
     """
 
-    def __init__(self, x, sf, f_pha=[2, 4], f_amp=[60, 80], n_bins=18,
-                 dcomplex='hilbert', cycle=(3, 6), width=7, edges=None,
-                 n_jobs=-1):
+    def __init__(
+        self,
+        x,
+        sf,
+        f_pha=[2, 4],
+        f_amp=[60, 80],
+        n_bins=18,
+        dcomplex="hilbert",
+        cycle=(3, 6),
+        width=7,
+        edges=None,
+        n_jobs=-1,
+    ):
         """Init."""
-        _PacObj.__init__(self, f_pha=f_pha, f_amp=f_amp, dcomplex=dcomplex,
-                         cycle=cycle, width=width)
+        _PacObj.__init__(
+            self, f_pha=f_pha, f_amp=f_amp, dcomplex=dcomplex, cycle=cycle, width=width
+        )
         # check
         x = np.atleast_2d(x)
-        assert x.ndim <= 2, ("`x` input should be an array of shape "
-                             "(n_epochs, n_times)")
-        assert isinstance(sf, (int, float)), ("`sf` input should be a integer "
-                                              "or a float")
-        assert all([isinstance(k, (int, float)) for k in f_pha]), (
-            "`f_pha` input should be a list of two integers / floats")
-        assert all([isinstance(k, (int, float)) for k in f_amp]), (
-            "`f_amp` input should be a list of two integers / floats")
+        assert x.ndim <= 2, (
+            "`x` input should be an array of shape " "(n_epochs, n_times)"
+        )
+        assert isinstance(sf, (int, float)), (
+            "`sf` input should be a integer " "or a float"
+        )
+        assert all(
+            [isinstance(k, (int, float)) for k in f_pha]
+        ), "`f_pha` input should be a list of two integers / floats"
+        assert all(
+            [isinstance(k, (int, float)) for k in f_amp]
+        ), "`f_amp` input should be a list of two integers / floats"
         assert isinstance(n_bins, int), "`n_bins` should be an integer"
-        logger.info(f"Binning {f_amp}Hz amplitude according to {f_pha}Hz "
-                    "phase")
+        logger.info(f"Binning {f_amp}Hz amplitude according to {f_pha}Hz " "phase")
         # extract phase and amplitude
         kw = dict(keepfilt=False, edges=edges, n_jobs=n_jobs)
-        pha = self.filter(sf, x, 'phase', **kw)
-        amp = self.filter(sf, x, 'amplitude', **kw)
+        pha = self.filter(sf, x, "phase", **kw)
+        amp = self.filter(sf, x, "amplitude", **kw)
         # binarize amplitude according to phase
         self._amplitude = _kl_hr(pha, amp, n_bins, mean_bins=False).squeeze()
         self.n_bins = n_bins
 
-    def plot(self, unit='rad', normalize=False, **kw):
+    def plot(self, unit="rad", normalize=False, **kw):
         """Plot the amplitude.
 
         Parameters
@@ -365,11 +428,12 @@ class BinAmplitude(_PacObj):
             The matplotlib axis that contains the figure
         """
         import matplotlib.pyplot as plt
-        assert unit in ['rad', 'deg']
-        if unit == 'rad':
+
+        assert unit in ["rad", "deg"]
+        if unit == "rad":
             self._phase = np.linspace(-np.pi, np.pi, self.n_bins)
             width = 2 * np.pi / self.n_bins
-        elif unit == 'deg':
+        elif unit == "deg":
             self._phase = np.linspace(-180, 180, self.n_bins)
             width = 360 / self.n_bins
         amp_mean = self._amplitude.mean(1)
@@ -379,11 +443,12 @@ class BinAmplitude(_PacObj):
         plt.xlabel(f"Frequency phase ({self.n_bins} bins)", fontsize=18)
         plt.ylabel("Amplitude", fontsize=18)
         plt.title("Binned amplitude")
-        plt.autoscale(enable=True, axis='x', tight=True)
+        plt.autoscale(enable=True, axis="x", tight=True)
 
     def show(self):
         """Show the figure."""
         import matplotlib.pyplot as plt
+
         plt.show()
 
     @property
@@ -424,23 +489,40 @@ class ITC(_PacObj, _PacVisual):
         Number of samples to discard to avoid edge effects due to filtering
     """
 
-    def __init__(self, x, sf, f_pha=[2, 4], dcomplex='hilbert', cycle=3,
-                 width=7, edges=None, n_jobs=-1, verbose=None):
+    def __init__(
+        self,
+        x,
+        sf,
+        f_pha=[2, 4],
+        dcomplex="hilbert",
+        cycle=3,
+        width=7,
+        edges=None,
+        n_jobs=-1,
+        verbose=None,
+    ):
         """Init."""
         set_log_level(verbose)
-        _PacObj.__init__(self, f_pha=f_pha, f_amp=[60, 80], dcomplex=dcomplex,
-                         cycle=(cycle, 6), width=width)
+        _PacObj.__init__(
+            self,
+            f_pha=f_pha,
+            f_amp=[60, 80],
+            dcomplex=dcomplex,
+            cycle=(cycle, 6),
+            width=width,
+        )
         _PacVisual.__init__(self)
         # check
         x = np.atleast_2d(x)
-        assert x.ndim <= 2, ("`x` input should be an array of shape "
-                             "(n_epochs, n_times)")
+        assert x.ndim <= 2, (
+            "`x` input should be an array of shape " "(n_epochs, n_times)"
+        )
         self._n_trials = x.shape[0]
         logger.info("Inter-Trials Coherence (ITC)")
         logger.info(f"    extracting {len(self.xvec)} phases")
         # extract phase and amplitude
         kw = dict(keepfilt=False, edges=edges, n_jobs=n_jobs)
-        pha = self.filter(sf, x, 'phase', **kw)
+        pha = self.filter(sf, x, "phase", **kw)
         # compute itc
         self._itc = np.abs(np.exp(1j * pha).mean(1)).squeeze()
         self._sf = sf
@@ -463,27 +545,36 @@ class ITC(_PacObj, _PacVisual):
             The matplotlib axis that contains the figure
         """
         import matplotlib.pyplot as plt
+
         n_pts = self._itc.shape[-1]
         if not isinstance(times, np.ndarray):
             times = np.arange(n_pts) / self._sf
         times = times[self._edges]
-        assert len(times) == n_pts, ("The length of the time vector should be "
-                                     "{n_pts}")
-        xlab = 'Time'
+        assert len(times) == n_pts, "The length of the time vector should be " "{n_pts}"
+        xlab = "Time"
         title = f"Inter-Trials Coherence ({self._n_trials} trials)"
         if self._itc.ndim == 1:
             plt.plot(times, self._itc, **kw)
         elif self._itc.ndim == 2:
-            vmin = kw.get('vmin', np.percentile(self._itc, 1))
-            vmax = kw.get('vmax', np.percentile(self._itc, 99))
-            self.pacplot(self._itc, times, self.xvec, vmin=vmin, vmax=vmax,
-                         ylabel="Frequency for phase (Hz)", xlabel=xlab,
-                         title=title, **kw)
+            vmin = kw.get("vmin", np.percentile(self._itc, 1))
+            vmax = kw.get("vmax", np.percentile(self._itc, 99))
+            self.pacplot(
+                self._itc,
+                times,
+                self.xvec,
+                vmin=vmin,
+                vmax=vmax,
+                ylabel="Frequency for phase (Hz)",
+                xlabel=xlab,
+                title=title,
+                **kw,
+            )
         return plt.gca()
 
     def show(self):
         """Show the figure."""
         import matplotlib.pyplot as plt
+
         plt.show()
 
     @property
@@ -548,13 +639,24 @@ class PeakLockedTF(_PacObj, _PacVisual):
         :cite:`bahramisharif2013propagating`.
     """
 
-    def __init__(self, x, sf, cue, times=None, f_pha=[5, 7], f_amp='hres',
-                 cycle=(3, 6), n_jobs=-1, verbose=None):
+    def __init__(
+        self,
+        x,
+        sf,
+        cue,
+        times=None,
+        f_pha=[5, 7],
+        f_amp="hres",
+        cycle=(3, 6),
+        n_jobs=-1,
+        verbose=None,
+    ):
         """Init."""
         set_log_level(verbose)
         # initialize to retrieve filtering methods
-        _PacObj.__init__(self, f_pha=f_pha, f_amp=f_amp, dcomplex='hilbert',
-                         cycle=cycle)
+        _PacObj.__init__(
+            self, f_pha=f_pha, f_amp=f_amp, dcomplex="hilbert", cycle=cycle
+        )
         _PacVisual.__init__(self)
         logger.info("PeakLockedTF object defined")
         # inputs checking
@@ -578,12 +680,11 @@ class PeakLockedTF(_PacObj, _PacVisual):
         self.cue, self._times = cue, times
 
         # extract phase and amplitudes
-        logger.info(f"    extract phase and amplitudes "
-                    f"(n_amps={len(self.yvec)})")
+        logger.info(f"    extract phase and amplitudes " f"(n_amps={len(self.yvec)})")
         kw = dict(keepfilt=False, n_jobs=n_jobs)
-        pha = self.filter(sf, x, 'phase', n_jobs=n_jobs, keepfilt=True)
-        amp = self.filter(sf, x, 'amplitude', n_jobs=n_jobs)
-        self._pha, self._amp = pha, amp ** 2
+        pha = self.filter(sf, x, "phase", n_jobs=n_jobs, keepfilt=True)
+        amp = self.filter(sf, x, "amplitude", n_jobs=n_jobs)
+        self._pha, self._amp = pha, amp**2
 
         # peak detection
         logger.info(f"    running peak detection around sample={cue}")
@@ -591,8 +692,8 @@ class PeakLockedTF(_PacObj, _PacVisual):
 
         # realign phases and amplitudes
         logger.info(f"    realign the {n_epochs} phases and amplitudes")
-        self.amp_a = self._shift_signals(self._amp, self.shifts, fill_with=0.)
-        self.pha_a = self._shift_signals(self._pha, self.shifts, fill_with=0.)
+        self.amp_a = self._shift_signals(self._amp, self.shifts, fill_with=0.0)
+        self.pha_a = self._shift_signals(self._pha, self.shifts, fill_with=0.0)
 
     @staticmethod
     def _peak_detection(pha, cue):
@@ -656,13 +757,12 @@ class PeakLockedTF(_PacObj, _PacVisual):
             # select the data of a specific trial
             st_shift = n_shifts[tr]
             st_sig = sig[:, tr, :]
-            fill = np.full((n_freqs, abs(st_shift)), fill_with,
-                           dtype=st_sig.dtype)
+            fill = np.full((n_freqs, abs(st_shift)), fill_with, dtype=st_sig.dtype)
             # shift this specific trial
-            if st_shift > 0:   # move forward = prepend zeros
+            if st_shift > 0:  # move forward = prepend zeros
                 sig_shifted[:, tr, :] = np.c_[fill, st_sig][:, 0:-st_shift]
             elif st_shift < 0:  # move backward = append zeros
-                sig_shifted[:, tr, :] = np.c_[st_sig, fill][:, abs(st_shift):]
+                sig_shifted[:, tr, :] = np.c_[st_sig, fill][:, abs(st_shift) :]
 
         return sig_shifted
 
@@ -688,13 +788,14 @@ class PeakLockedTF(_PacObj, _PacVisual):
         """
         import matplotlib.pyplot as plt
         from matplotlib.gridspec import GridSpec
+
         # manage additional arguments
-        kwargs['colorbar'] = False
-        kwargs['ylabel'] = 'Frequency for amplitude (hz)'
-        kwargs['xlabel'] = ''
-        kwargs['fz_labels'] = kwargs.get('fz_labels', 14)
-        kwargs['fz_cblabel'] = kwargs.get('fz_cblabel', 14)
-        kwargs['fz_title'] = kwargs.get('fz_title', 16)
+        kwargs["colorbar"] = False
+        kwargs["ylabel"] = "Frequency for amplitude (hz)"
+        kwargs["xlabel"] = ""
+        kwargs["fz_labels"] = kwargs.get("fz_labels", 14)
+        kwargs["fz_cblabel"] = kwargs.get("fz_cblabel", 14)
+        kwargs["fz_title"] = kwargs.get("fz_title", 16)
         sl_times = slice(edges, len(self._times) - edges)
         times = self._times[sl_times]
         pha_n = self.pha_a[..., sl_times].squeeze()
@@ -707,7 +808,7 @@ class PeakLockedTF(_PacObj, _PacVisual):
                 bsl_idx = slice(baseline[0], baseline[1])
             _mean = self.amp_a[..., bsl_idx].mean(2, keepdims=True)
             _std = self.amp_a[..., bsl_idx].std(2, keepdims=True)
-            _std[_std == 0.] = 1.  # correction from NaN
+            _std[_std == 0.0] = 1.0  # correction from NaN
             amp_n = (self.amp_a[..., sl_times] - _mean) / _std
         else:
             amp_n = self.amp_a[..., sl_times]
@@ -717,28 +818,27 @@ class PeakLockedTF(_PacObj, _PacVisual):
         # image plot
         plt.subplot(gs[slice(0, 6), 0:-1])
         self.pacplot(amp_n.mean(1), times, self.yvec, **kwargs)
-        plt.axvline(times[self.cue], color='w', lw=2)
+        plt.axvline(times[self.cue], color="w", lw=2)
         plt.tick_params(bottom=False, labelbottom=False)
         ax_1 = plt.gca()
         # external colorbar
         plt.subplot(gs[slice(1, 5), -1])
         cb = plt.colorbar(self._plt_im, pad=0.01, cax=plt.gca())
-        cb.set_label('Power (V**2/Hz)', fontsize=kwargs['fz_cblabel'])
+        cb.set_label("Power (V**2/Hz)", fontsize=kwargs["fz_cblabel"])
         cb.outline.set_visible(False)
         # phase plot
         plt.subplot(gs[slice(6, 8), 0:-1])
-        plt.plot(times, pha_n.T, color='lightgray', alpha=.2, lw=1.)
-        plt.plot(times, pha_n.mean(0), label='single trial phases', alpha=.2,
-                 lw=1.)  # legend tweaking
-        plt.plot(times, pha_n.mean(0), label='mean phases',
-                 color='#1f77b4')
-        plt.axvline(times[self.cue], color='k', lw=2)
-        plt.autoscale(axis='both', tight=True, enable=True)
-        plt.xlabel("Times", fontsize=kwargs['fz_labels'])
-        plt.ylabel("V / Hz", fontsize=kwargs['fz_labels'])
+        plt.plot(times, pha_n.T, color="lightgray", alpha=0.2, lw=1.0)
+        plt.plot(
+            times, pha_n.mean(0), label="single trial phases", alpha=0.2, lw=1.0
+        )  # legend tweaking
+        plt.plot(times, pha_n.mean(0), label="mean phases", color="#1f77b4")
+        plt.axvline(times[self.cue], color="k", lw=2)
+        plt.autoscale(axis="both", tight=True, enable=True)
+        plt.xlabel("Times", fontsize=kwargs["fz_labels"])
+        plt.ylabel("V / Hz", fontsize=kwargs["fz_labels"])
         # bottom legend
-        plt.legend(loc='center', bbox_to_anchor=(.5, -.5),
-                   fontsize='x-large', ncol=2)
+        plt.legend(loc="center", bbox_to_anchor=(0.5, -0.5), fontsize="x-large", ncol=2)
         ax_2 = plt.gca()
 
         return [ax_1, ax_2]


### PR DESCRIPTION
In newer releases of Matplotlib 'basex' has been changed to 'base'. 

See also: https://matplotlib.org/stable/api/scale_api.html#matplotlib.scale.LogScale
The older version where basex was still in use: https://matplotlib.org/2.2.4/api/scale_api.html (this is the last version I could find where basex was still in use)